### PR TITLE
feat: add node service skeleton

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+META_VERIFY_TOKEN=your_verify_token
+META_ACCESS_TOKEN=your_access_token
+META_PHONE_NUMBER_ID=your_phone_number_id
+WHATSAPP_API_URL=https://graph.facebook.com/v20.0/your_phone_number_id/messages
+RAZORPAY_KEY_SECRET=your_razorpay_secret
+REDIS_URL=redis://localhost:6379
+ORDERS_CSV=orders.csv

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ venv/
 __pycache__/
 *.pyc
 data/
+node_modules/
+.env

--- a/config/credentials.js
+++ b/config/credentials.js
@@ -1,0 +1,9 @@
+require('dotenv').config();
+
+module.exports = {
+  META_VERIFY_TOKEN: process.env.META_VERIFY_TOKEN,
+  META_ACCESS_TOKEN: process.env.META_ACCESS_TOKEN,
+  META_PHONE_NUMBER_ID: process.env.META_PHONE_NUMBER_ID,
+  WHATSAPP_API_URL: process.env.WHATSAPP_API_URL,
+  RAZORPAY_KEY_SECRET: process.env.RAZORPAY_KEY_SECRET
+};

--- a/config/settings.js
+++ b/config/settings.js
@@ -1,0 +1,4 @@
+module.exports = {
+  ADMIN_NUMBERS: (process.env.ADMIN_NUMBERS || '').split(',').filter(Boolean),
+  ORDERS_CSV: process.env.ORDERS_CSV || 'orders.csv'
+};

--- a/handlers/messageHandlers.js
+++ b/handlers/messageHandlers.js
@@ -1,0 +1,54 @@
+const { sendTextMessage } = require('../services/whatsappService');
+const { getUserState, setUserState } = require('../stateHandlers/redisState');
+
+async function handleIncomingMessage(data) {
+  for (const entry of data.entry || []) {
+    for (const change of entry.changes || []) {
+      const value = change.value || {};
+      const messages = value.messages || [];
+      if (!messages.length) continue;
+      const msg = messages[0];
+      const sender = msg.from.replace(/^\+/, '');
+      const type = msg.type;
+      if (type === 'text') {
+        await handleGreeting(sender);
+      } else if (type === 'location') {
+        const { latitude, longitude } = msg.location;
+        await handleLocation(sender, latitude, longitude);
+      } else if (type === 'order') {
+        const items = msg.order?.product_items || [];
+        await handleOrder(sender, items);
+      } else if (type === 'interactive') {
+        await handleInteractive(sender, msg.interactive);
+      }
+    }
+  }
+}
+
+async function handleGreeting(to) {
+  await sendTextMessage(to, '👋 Hello! How can we help you today?');
+  await setUserState(to, { step: 'greeted' });
+}
+
+async function handleLocation(to, latitude, longitude) {
+  const state = await getUserState(to);
+  state.location = { latitude, longitude };
+  await setUserState(to, state);
+  await sendTextMessage(to, '📍 Location received.');
+}
+
+async function handleOrder(to, items) {
+  await sendTextMessage(to, '🛒 Order received.');
+}
+
+async function handleInteractive(to, interactive) {
+  await sendTextMessage(to, '🔘 Option selected.');
+}
+
+module.exports = {
+  handleIncomingMessage,
+  handleGreeting,
+  handleLocation,
+  handleOrder,
+  handleInteractive
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "main",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"No tests\""
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/scheduler/backgroundJobs.js
+++ b/scheduler/backgroundJobs.js
@@ -1,0 +1,37 @@
+const cron = require('node-cron');
+const moment = require('moment-timezone');
+const { sendCartReminderOnce } = require('../services/orderService');
+const { getAllCarts, getPendingOrders, removePendingOrder } = require('../stateHandlers/redisState');
+const { sendTextMessage } = require('../services/whatsappService');
+
+function startJobs() {
+  cron.schedule('*/10 * * * *', sendCartReminders, { timezone: 'Asia/Kolkata' });
+  cron.schedule('* * * * *', checkPendingOrders, { timezone: 'Asia/Kolkata' });
+}
+
+async function sendCartReminders() {
+  const carts = await getAllCarts();
+  const now = moment.tz('Asia/Kolkata');
+  for (const [phone, cart] of Object.entries(carts)) {
+    if (!cart.last_interaction_time || cart.reminder_sent) continue;
+    const last = moment.tz(cart.last_interaction_time, 'YYYY-MM-DD HH:mm:ss', 'Asia/Kolkata');
+    if (now.diff(last, 'minutes') >= 5) {
+      await sendCartReminderOnce(phone);
+    }
+  }
+}
+
+async function checkPendingOrders() {
+  const orders = await getPendingOrders();
+  const now = moment.utc();
+  for (const [orderId, order] of Object.entries(orders)) {
+    if (order.status !== 'Pending') continue;
+    const created = moment.utc(order.created_at);
+    if (now.diff(created, 'minutes') >= 3) {
+      await sendTextMessage(order.customer, `❌ Your order ${orderId} has been cancelled due to inactivity.`);
+      await removePendingOrder(orderId);
+    }
+  }
+}
+
+module.exports = { startJobs };

--- a/server.js
+++ b/server.js
@@ -1,0 +1,72 @@
+const express = require('express');
+const crypto = require('crypto');
+const dotenv = require('dotenv');
+const logger = require('./utils/logger');
+const { META_VERIFY_TOKEN, RAZORPAY_KEY_SECRET } = require('./config/credentials');
+const { handleIncomingMessage } = require('./handlers/messageHandlers');
+const { confirmOrder } = require('./services/orderService');
+const { startJobs } = require('./scheduler/backgroundJobs');
+
+dotenv.config();
+
+const app = express();
+app.use(express.json());
+
+app.get('/webhook', (req, res) => {
+  const mode = req.query['hub.mode'];
+  const token = req.query['hub.verify_token'];
+  const challenge = req.query['hub.challenge'];
+  if (mode === 'subscribe' && token === META_VERIFY_TOKEN) {
+    logger.info('Webhook verified');
+    return res.status(200).send(challenge);
+  }
+  logger.warn('Webhook verification failed');
+  return res.sendStatus(403);
+});
+
+app.post('/webhook', async (req, res) => {
+  logger.info('Incoming webhook payload');
+  try {
+    await handleIncomingMessage(req.body);
+  } catch (err) {
+    logger.error('Error handling incoming message', { error: err.message });
+  }
+  res.sendStatus(200);
+});
+
+app.get('/payment-success', async (req, res) => {
+  const whatsapp = req.query.whatsapp;
+  const orderId = req.query.order_id;
+  if (whatsapp && orderId) {
+    await confirmOrder(whatsapp, 'Online', orderId, true);
+  }
+  res.status(200).send('Payment confirmed');
+});
+
+app.post('/razorpay-webhook-fruitcustard', express.raw({ type: 'application/json' }), (req, res) => {
+  const receivedSignature = req.headers['x-razorpay-signature'] || '';
+  const expected = crypto
+    .createHmac('sha256', RAZORPAY_KEY_SECRET || '')
+    .update(req.body)
+    .digest('hex');
+  if (!crypto.timingSafeEqual(Buffer.from(receivedSignature), Buffer.from(expected))) {
+    logger.warn('Invalid Razorpay signature');
+    return res.status(400).send('Invalid signature');
+  }
+  const data = JSON.parse(req.body.toString());
+  if (data.event === 'payment_link.paid') {
+    const payment = data.payload?.payment_link?.entity || {};
+    const whatsapp = payment.customer?.contact;
+    const orderId = payment.reference_id;
+    if (whatsapp && orderId) {
+      confirmOrder(whatsapp, 'Online', orderId, true);
+    }
+  }
+  res.send('OK');
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => logger.info(`Server listening on port ${PORT}`));
+startJobs();
+
+module.exports = app;

--- a/services/orderService.js
+++ b/services/orderService.js
@@ -1,0 +1,48 @@
+const fs = require('fs');
+const path = require('path');
+const csv = require('fast-csv');
+const moment = require('moment-timezone');
+const { sendTextMessage, sendTemplate } = require('./whatsappService');
+const { getUserCart, setUserCart, deleteUserCart, addPendingOrder } = require('../stateHandlers/redisState');
+const { ORDERS_CSV } = require('../config/settings');
+
+function logOrder(order) {
+  const filePath = path.resolve(ORDERS_CSV || 'orders.csv');
+  const exists = fs.existsSync(filePath);
+  const ws = fs.createWriteStream(filePath, { flags: 'a' });
+  csv.write([order], { headers: !exists }).pipe(ws);
+}
+
+async function sendCartReminderOnce(phone) {
+  const cart = await getUserCart(phone);
+  if (!cart.summary || cart.reminder_sent) return;
+  await sendTextMessage(phone, `🛒 Just a reminder! You still have items in your cart.\n${cart.summary}`);
+  await sendTemplate(phone, 'delivery_takeaway');
+  cart.reminder_sent = true;
+  await setUserCart(phone, cart);
+}
+
+async function confirmOrder(to, paymentMode, orderId, paid = false) {
+  const cart = await getUserCart(to);
+  const orderData = {
+    customer: to,
+    order_id: orderId,
+    payment_mode: paymentMode,
+    summary: cart.summary || '',
+    total: cart.total || 0,
+    status: 'Pending',
+    created_at: moment.utc().toISOString()
+  };
+  logOrder({
+    'Order ID': orderId,
+    'Customer Number': to,
+    'Order Time': moment().tz('Asia/Kolkata').format('YYYY-MM-DD HH:mm:ss'),
+    'Payment Mode': paymentMode,
+    'Paid': paid
+  });
+  await addPendingOrder(orderId, orderData);
+  await deleteUserCart(to);
+  await sendTextMessage(to, `✅ Order confirmed. Your order ID is ${orderId}.`);
+}
+
+module.exports = { logOrder, sendCartReminderOnce, confirmOrder };

--- a/services/whatsappService.js
+++ b/services/whatsappService.js
@@ -1,0 +1,55 @@
+const axios = require('axios');
+const { META_ACCESS_TOKEN, META_PHONE_NUMBER_ID, WHATSAPP_API_URL } = require('../config/credentials');
+const logger = require('../utils/logger');
+
+async function sendTextMessage(to, body) {
+  try {
+    await axios.post(
+      WHATSAPP_API_URL || `https://graph.facebook.com/v20.0/${META_PHONE_NUMBER_ID}/messages`,
+      {
+        messaging_product: 'whatsapp',
+        to,
+        type: 'text',
+        text: { body }
+      },
+      {
+        headers: {
+          Authorization: `Bearer ${META_ACCESS_TOKEN}`,
+          'Content-Type': 'application/json'
+        }
+      }
+    );
+    logger.info('Sent WhatsApp message', { to });
+  } catch (err) {
+    logger.error('Failed to send WhatsApp message', { error: err.message });
+  }
+}
+
+async function sendTemplate(to, name, components = []) {
+  try {
+    await axios.post(
+      WHATSAPP_API_URL || `https://graph.facebook.com/v20.0/${META_PHONE_NUMBER_ID}/messages`,
+      {
+        messaging_product: 'whatsapp',
+        to,
+        type: 'template',
+        template: {
+          name,
+          language: { code: 'en_US' },
+          components
+        }
+      },
+      {
+        headers: {
+          Authorization: `Bearer ${META_ACCESS_TOKEN}`,
+          'Content-Type': 'application/json'
+        }
+      }
+    );
+    logger.info('Sent template message', { to, name });
+  } catch (err) {
+    logger.error('Failed to send template', { error: err.message });
+  }
+}
+
+module.exports = { sendTextMessage, sendTemplate };

--- a/stateHandlers/redisState.js
+++ b/stateHandlers/redisState.js
@@ -1,0 +1,80 @@
+const { createClient } = require('redis');
+const logger = require('../utils/logger');
+
+const client = createClient({ url: process.env.REDIS_URL || 'redis://localhost:6379' });
+client.on('error', err => logger.error('Redis error', { error: err.message }));
+client.connect().catch(err => logger.error('Redis connection failed', { error: err.message }));
+
+async function getUserCart(phone) {
+  const data = await client.get(`user_cart:${phone}`);
+  return data ? JSON.parse(data) : {};
+}
+
+async function setUserCart(phone, cart) {
+  await client.set(`user_cart:${phone}`, JSON.stringify(cart), { EX: 86400 });
+}
+
+async function deleteUserCart(phone) {
+  await client.del(`user_cart:${phone}`);
+}
+
+async function getAllCarts() {
+  const keys = await client.keys('user_cart:*');
+  const result = {};
+  for (const key of keys) {
+    const data = await client.get(key);
+    result[key.split(':')[1]] = JSON.parse(data);
+  }
+  return result;
+}
+
+async function getUserState(phone) {
+  const data = await client.get(`user_state:${phone}`);
+  return data ? JSON.parse(data) : {};
+}
+
+async function setUserState(phone, state) {
+  await client.set(`user_state:${phone}`, JSON.stringify(state), { EX: 86400 });
+}
+
+async function deleteUserState(phone) {
+  await client.del(`user_state:${phone}`);
+}
+
+async function addPendingOrder(orderId, data) {
+  await client.set(`order:${orderId.toUpperCase()}`, JSON.stringify(data));
+}
+
+async function getPendingOrder(orderId) {
+  const data = await client.get(`order:${orderId.toUpperCase()}`);
+  return data ? JSON.parse(data) : null;
+}
+
+async function getPendingOrders() {
+  const keys = await client.keys('order:*');
+  const result = {};
+  for (const key of keys) {
+    const data = await client.get(key);
+    result[key.split(':')[1]] = JSON.parse(data);
+  }
+  return result;
+}
+
+async function removePendingOrder(orderId) {
+  await client.del(`order:${orderId.toUpperCase()}`);
+}
+
+module.exports = {
+  client,
+  getUserCart,
+  setUserCart,
+  deleteUserCart,
+  getAllCarts,
+  getUserState,
+  setUserState,
+  deleteUserState,
+  addPendingOrder,
+  getPendingOrder,
+  getPendingOrders,
+  removePendingOrder
+};

--- a/utils/logger.js
+++ b/utils/logger.js
@@ -1,0 +1,9 @@
+const { createLogger, format, transports } = require('winston');
+
+const logger = createLogger({
+  level: 'info',
+  format: format.combine(format.timestamp(), format.json()),
+  transports: [new transports.Console()]
+});
+
+module.exports = logger;


### PR DESCRIPTION
## Summary
- bootstrap Node.js project with Express server, webhook verification, and Razorpay payment webhook
- add message handlers, Redis state module, background cron jobs, and service utilities
- configure environment and logging with dotenv and Winston

## Testing
- `npm test`
- `npm install express axios redis node-cron dotenv moment-timezone fast-csv winston whatsapp-cloud-api` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689ebbeb113c8327adf0e9100c5e33ab