### PR TITLE
Add geodesic branch lookup and enhance location handling

### DIFF
--- a/config/settings.js
+++ b/config/settings.js
@@ -1,4 +1,25 @@
 module.exports = {
   ADMIN_NUMBERS: (process.env.ADMIN_NUMBERS || '').split(',').filter(Boolean),
-  ORDERS_CSV: process.env.ORDERS_CSV || 'orders.csv'
+  ORDERS_CSV: process.env.ORDERS_CSV || 'orders.csv',
+  BRANCH_STATUS: {
+    kondapur: true,
+    madhapur: true,
+    manikonda: true,
+    nizampet: true,
+    nanakramguda: true
+  },
+  BRANCH_DISCOUNTS: {
+    kondapur: 0,
+    madhapur: 0,
+    manikonda: 0,
+    nizampet: 0,
+    nanakramguda: 0
+  },
+  BRANCH_BLOCKED_USERS: {
+    kondapur: new Set(),
+    madhapur: new Set(),
+    manikonda: new Set(),
+    nizampet: new Set(),
+    nanakramguda: new Set()
+  }
 };

--- a/handlers/messageHandlers.js
+++ b/handlers/messageHandlers.js
@@ -1,5 +1,7 @@
-const { sendTextMessage } = require('../services/whatsappService');
+const { sendTextMessage, sendTemplate } = require('../services/whatsappService');
 const { getUserState, setUserState } = require('../stateHandlers/redisState');
+const { BRANCH_STATUS, BRANCH_DISCOUNTS, BRANCH_BLOCKED_USERS } = require('../config/settings');
+const { findClosestBranch } = require('../utils/locationUtils');
 
 async function handleIncomingMessage(data) {
   for (const entry of data.entry || []) {
@@ -31,10 +33,30 @@ async function handleGreeting(to) {
 }
 
 async function handleLocation(to, latitude, longitude) {
+  const branchInfo = findClosestBranch(latitude, longitude);
+  if (!branchInfo) {
+    await sendTextMessage(to, '🚫 Sorry, we do not serve your location yet.');
+    return;
+  }
+
+  const branchKey = branchInfo.name.toLowerCase();
+  if (!BRANCH_STATUS[branchKey]) {
+    if (!BRANCH_BLOCKED_USERS[branchKey]) {
+      BRANCH_BLOCKED_USERS[branchKey] = new Set();
+    }
+    BRANCH_BLOCKED_USERS[branchKey].add(to);
+    await sendTextMessage(to, `🚫 ${branchInfo.name} branch is currently unavailable.`);
+    return;
+  }
+
   const state = await getUserState(to);
+  state.branch = branchKey;
   state.location = { latitude, longitude };
+  state.discount = BRANCH_DISCOUNTS[branchKey] || 0;
   await setUserState(to, state);
-  await sendTextMessage(to, '📍 Location received.');
+
+  await sendTextMessage(to, `📍 Closest branch: ${branchInfo.name}\n${branchInfo.map_link}`);
+  await sendTemplate(to, 'delivery_takeaway');
 }
 
 async function handleOrder(to, items) {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "scripts": {
     "test": "echo \"No tests\""
   },
+  "dependencies": {
+    "geolib": "^3.3.3"
+  },
   "keywords": [],
   "author": "",
   "license": "ISC",

--- a/utils/locationUtils.js
+++ b/utils/locationUtils.js
@@ -1,0 +1,26 @@
+const { getDistance } = require('geolib');
+const branches = require('../data/branches.json');
+
+const DEFAULT_RADIUS_KM = Number(process.env.BRANCH_RADIUS_KM || 3);
+
+function findClosestBranch(latitude, longitude, radiusKm = DEFAULT_RADIUS_KM) {
+  let closest = null;
+  let minDistance = Infinity;
+  for (const [name, info] of Object.entries(branches)) {
+    const [branchLat, branchLon] = info.coordinates;
+    const distance = getDistance(
+      { latitude, longitude },
+      { latitude: branchLat, longitude: branchLon }
+    );
+    if (distance < minDistance) {
+      minDistance = distance;
+      closest = { name, map_link: info.map_link, contact: info.contact, distance };
+    }
+  }
+  if (closest && minDistance <= radiusKm * 1000) {
+    return closest;
+  }
+  return null;
+}
+
+module.exports = { findClosestBranch };


### PR DESCRIPTION
## Summary
- add utility to find nearest branch using geodesic distance
- store branch details and discounts in Redis while offering delivery/takeaway template
- track branch availability and block users when branch is offline

## Testing
- `npm test`
- `node -e "console.log(require('./utils/locationUtils').findClosestBranch(17.47019976442252,78.35272372527311))"` *(fails: Cannot find module 'geolib')*
- `npm install geolib` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a01dbc231483279b57739bb18d1a33