### PR TITLE
Manage branch open/close commands

### DIFF
--- a/config/branchConfig.js
+++ b/config/branchConfig.js
@@ -1,0 +1,4 @@
+const BRANCH_STATUS = {};
+const BRANCH_BLOCKED_USERS = {};
+
+module.exports = { BRANCH_STATUS, BRANCH_BLOCKED_USERS };

--- a/handlers/messageHandlers.js
+++ b/handlers/messageHandlers.js
@@ -1,5 +1,7 @@
 const { sendTextMessage } = require('../services/whatsappService');
 const { getUserState, setUserState } = require('../stateHandlers/redisState');
+const { ADMIN_NUMBERS } = require('../config/settings');
+const { BRANCH_STATUS, BRANCH_BLOCKED_USERS } = require('../config/branchConfig');
 
 async function handleIncomingMessage(data) {
   for (const entry of data.entry || []) {
@@ -11,7 +13,26 @@ async function handleIncomingMessage(data) {
       const sender = msg.from.replace(/^\+/, '');
       const type = msg.type;
       if (type === 'text') {
-        await handleGreeting(sender);
+        const textBody = msg.text?.body?.trim() || '';
+        const match = textBody.match(/^(open|close)\s+(\w+)/i);
+        if (match && ADMIN_NUMBERS.includes(sender)) {
+          const action = match[1].toLowerCase();
+          const branch = match[2];
+          if (action === 'open') {
+            BRANCH_STATUS[branch] = true;
+            const blocked = BRANCH_BLOCKED_USERS[branch] || [];
+            for (const user of blocked) {
+              await sendTextMessage(user, `Branch ${branch} is now open.`);
+            }
+            BRANCH_BLOCKED_USERS[branch] = [];
+            await sendTextMessage(sender, `Branch ${branch} opened.`);
+          } else {
+            BRANCH_STATUS[branch] = false;
+            await sendTextMessage(sender, `Branch ${branch} closed.`);
+          }
+        } else {
+          await handleGreeting(sender);
+        }
       } else if (type === 'location') {
         const { latitude, longitude } = msg.location;
         await handleLocation(sender, latitude, longitude);


### PR DESCRIPTION
## Summary
- handle `open <branch>` and `close <branch>` text commands from admins
- track branch status and blocked users in new config module
- notify blocked users when a branch opens and confirm closures to admins

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a01dbf81248327816870a9bce0ca6c